### PR TITLE
Embed default config file

### DIFF
--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,14 +1,12 @@
 package testutils
 
 import (
-	"log"
 	"os"
 	"path"
 	"runtime"
 	"testing"
 
 	"github.com/carboniferio/carbonifer/internal/utils"
-	"github.com/spf13/viper"
 )
 
 var RootDir string
@@ -20,13 +18,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	utils.LoadViperDefaults()
-	viper.AddConfigPath(path.Join(RootDir, "test/config"))
-	viper.SetConfigName("default_conf")
-	viper.SetConfigType("yaml")
-	if err := viper.ReadInConfig(); err != nil {
-		log.Fatal(err)
-	}
+	utils.InitConfig(path.Join(RootDir, "test/config/default_conf.yaml"))
 
 	// Set fake GCP auth
 	os.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", "foo")

--- a/internal/utils/defaults.yaml
+++ b/internal/utils/defaults.yaml
@@ -20,3 +20,5 @@ provider:
     disk:
       size: 500
       type: pd-standard
+log:
+  level : "warn"


### PR DESCRIPTION
fixes #46

This will make sure `internal/utils/defaults.yaml` is embedded in compiled binary file as it's used to set Viper defaults with `viper.SetDefault()` 

Also, I moved all config setup out of `root.go` as it might  also benefit to the future library. 