### PR TITLE
Adding first support for Google Kubernetes Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Reading Terraform files, `carbonifer plan` will estimate future Carbon Emissions
 
 ## Scope
 
+This tool currently estimates usage emissions, not embodied emissions (manufacturing, transport, recycling...). It is not a full LCA (Life Cycle Assessment) tool.
+
 This tool can analyze Infrastructure as Code definitions such as:
 
 - [Terraform](https://www.terraform.io/) files
@@ -24,6 +26,7 @@ It can estimate Carbon Emissions of:
     - [X] Machines with GPUs
     - [x] Cloud SQL
     - [x] Instance Group (including regional and Autoscaler)
+    - [x] Google Kubernetes Engine (GKE) cluster
 - Amazon Web Services
   - [x] EC2 (including inline root, elastic, and ephemeral block storages)
   - [x] EBS Volumes
@@ -324,10 +327,10 @@ Those calculations and estimations are detailed in the [Methodology document](do
 
 We are currently supporting only
 
-- resources with a significative power usage (basically anything which has CPU, GPU, memory or disk)
+- resources with a significative power usage (basically anything that has CPU, GPU, memory or disk)
 - resources that can be estimated beforehand (we discard for now data transfer)
 
-Because this is just an estimation, the actual power usage and carbon emission should probably differ depending on the actual usage of the resource (CPU %), and actual grid energy mix (could be weather dependent), ... But that should be enough to take decisions about the choice of provider/region, instance type...
+Because this is just an estimation, the actual power usage and carbon emission should probably differ depending on the actual usage of the resource (CPU %), and actual grid energy mix (could be weather dependent), ... But that should be enough to make decisions about the choice of provider/region, instance type...
 
 See the [Scope](doc/scope.md) document for more details.
 

--- a/doc/methodology.md
+++ b/doc/methodology.md
@@ -5,6 +5,8 @@ Those are just "estimations" and will probably differ from the actual energy use
 
 In summary, for each resource, Carbonifer calculate an [Energy Estimate](#energy-estimate) (Watt per Hour) used by it, and multiply it by the [Carbon Intensity](#carbon-intensity) of the underlying data center.
 
+This tool currently estimates usage emissions, not embodied emissions (manufacturing, transport, recycling...). It is not a full LCA (Life Cycle Assessment) tool.
+
 ```text
 Estimated Carbon Emissions (gCO2eq/h) = Energy Estimate (Wh) x Carbon Intensity (gCO2eq/Wh)
 ```

--- a/doc/scope.md
+++ b/doc/scope.md
@@ -30,6 +30,7 @@ Not all resource types need to be supported if their energy use is negligible or
 | `google_compute_disk`| `size` needs to be set, otherwise get it from image| |
 | `google_compute_region_disk` | `size` needs to be set, otherwise get it from image| |
 | `google_sql_database_instance`  | | Custom machine also supported |
+| `google_container_cluster`  | | With default or referenced pool (`google_container_node_pool`) |
 
 Data resources:
 

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -35,7 +35,7 @@ func GenerateReportText(report estimation.EstimationReport) string {
 	for _, resource := range report.UnsupportedResources {
 		table.Append([]string{
 			resource.GetIdentification().ResourceType,
-			resource.GetIdentification().Name,
+			resource.GetIdentification().Address,
 			"",
 			"unsupported",
 		})

--- a/internal/plan/json.go
+++ b/internal/plan/json.go
@@ -6,12 +6,10 @@ import (
 	"github.com/carboniferio/carbonifer/internal/utils"
 )
 
-const allResourcesQuery = ".planned_values | .. | objects | select(has(\"resources\")) | .resources[]"
-
 func getJSON(query string, json interface{}) ([]interface{}, error) {
 
-	if strings.HasPrefix(query, "select(") {
-		results, err := utils.GetJSON(allResourcesQuery+" | "+query, *TfPlan)
+	if strings.Contains(query, "all_select(") {
+		results, err := utils.GetJSON(query, *TfPlan)
 		if len(results) > 0 && err == nil {
 			return results, nil
 		}

--- a/internal/plan/json_getters.go
+++ b/internal/plan/json_getters.go
@@ -253,6 +253,11 @@ func getValue(key string, context *tfContext) (*valueWithUnit, error) {
 			}
 		}
 
+		err = applyValidator(valueFound, &propertyMapping, context)
+		if err != nil {
+			return nil, err
+		}
+
 		if valueFound != nil {
 			return &valueWithUnit{
 				Value: valueFound,
@@ -374,6 +379,10 @@ func getDefaultValue(key string, context *tfContext) (*valueWithUnit, error) {
 				if err != nil {
 					return nil, err
 				}
+			}
+			err = applyValidator(valueFound, &propertyMapping, context)
+			if err != nil {
+				return nil, err
 			}
 
 			if valueFound != nil {

--- a/internal/plan/mappingStructs.go
+++ b/internal/plan/mappingStructs.go
@@ -33,6 +33,7 @@ type PropertyDefinition struct {
 	Reference *Reference         `yaml:"reference,omitempty"`
 	Regex     *Regex             `yaml:"regex,omitempty"`
 	Item      *[]ResourceMapping `yaml:"item,omitempty"`
+	Validator *string            `yaml:"validator,omitempty"`
 }
 
 type Reference struct {

--- a/internal/plan/mappings/aws/ec2_ebs.yaml
+++ b/internal/plan/mappings/aws/ec2_ebs.yaml
@@ -1,7 +1,7 @@
 compute_resource:
   aws_ebs_volume:
     paths:
-      - select(.type == "aws_ebs_volume")
+      - cbf::all_select("type";  "aws_ebs_volume")
     type: resource
     properties:
       name:

--- a/internal/plan/mappings/aws/ec2_instance.yaml
+++ b/internal/plan/mappings/aws/ec2_instance.yaml
@@ -1,13 +1,13 @@
 compute_resource:
   aws_instance: 
     paths: 
-      - select(.type == "aws_instance")
+      - cbf::all_select("type";  "aws_instance")
     type: resource
     variables:
       properties:
         ami:
           - paths:
-            - select(.values.image_id == "${this.values.ami}")
+            - cbf::all_select("values.image_id";  "${this.values.ami}")
             reference:
               return_path: true
         provider_region:

--- a/internal/plan/mappings/aws/rds_instance.yaml
+++ b/internal/plan/mappings/aws/rds_instance.yaml
@@ -1,17 +1,17 @@
 compute_resource:
   aws_db_instance: 
     paths: 
-      - select(.type == "aws_db_instance")
+      - cbf::all_select("type";  "aws_db_instance")
     type: resource
     variables:
       properties:
         replicate_source_db:
           - paths:
-            - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.replicate_source_db?.references[]? | select(endswith("id")) | gsub("\\.id$"; "")'
+            - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.replicate_source_db?.references[]? | select(endswith(".id") or endswith(".name")) | gsub("\\.(id|name)$"; "")'
             reference:
               paths:
-                - select(.address == "${key}")
-                - select(.address == ("${key}" | split(".")[0:2] | join("."))) | .resources[] | select(.name == ("${key}" | split(".")[2]))
+                - cbf::all_select("address";  "${key}")
+                - cbf::all_select("address"; ("${key}" | split(".")[0:2] | join("."))) | .resources[] | select(.name",  ("${key}" | split(".")[2]))
                 - .prior_state.values.root_module.resources[] | select(.address == "${key}")
               return_path: true
     properties:

--- a/internal/plan/mappings/gcp/compute.yaml
+++ b/internal/plan/mappings/gcp/compute.yaml
@@ -1,6 +1,6 @@
 compute_resource:
   google_compute_instance:
-    paths: 'select(.type == "google_compute_instance")'
+    paths: 'cbf::all_select("type";  "google_compute_instance")'
     type: resource
     properties:
       name:
@@ -91,16 +91,16 @@ compute_resource:
                   - default: ssd
   google_compute_instance_from_template:
     paths:
-      - select(.type == "google_compute_instance_from_template")
+      - cbf::all_select("type";  "google_compute_instance_from_template")
     type: resource
     variables:
       properties:
         template_config:
           - paths:
-            - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.source_instance_template.references[] | select(endswith("id")) | gsub("\\.id$"; "")'
+            - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.source_instance_template.references[] | select(endswith(".id") or endswith(".name")) | gsub("\\.(id|name)$"; "")'
             reference:
               paths:
-                - select(.address == "${key}")
+                - cbf::all_select("address";  "${key}")
                 - .planned_values.root_module.child_modules[] | select(.address == ("${key}" | split(".")[0:2] | join("."))) | .resources[] | select(.name == ("${key}" | split(".")[2]))
                 - .prior_state.values.root_module.resources[] | select(.address == "${key}")
               return_path: true

--- a/internal/plan/mappings/gcp/compute_group.yaml
+++ b/internal/plan/mappings/gcp/compute_group.yaml
@@ -1,17 +1,17 @@
 compute_resource:
   google_compute_instance_group_manager:
     paths:
-      - select(.type == "google_compute_instance_group_manager")
-      - select(.type == "google_compute_region_instance_group_manager")
+      - cbf::all_select("type";  "google_compute_instance_group_manager")
+      - cbf::all_select("type";  "google_compute_region_instance_group_manager")
     type: resource
     variables:
       properties:
         template_config:
           - paths:
-              - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.version[0].instance_template.references[] | select(endswith("id")) | gsub("\\.id$"; "")'
+              - '.configuration.root_module.resources[] | select(.address == "${this.address}") | .expressions.version[0].instance_template.references[] | select(endswith(".id") or endswith(".name")) | gsub("\\.(id|name)$"; "")'
             reference:
               paths:
-                - select(.address == "${key}")
+                - cbf::all_select("address";  "${key}")
                 - .prior_state.values.root_module.resources[] | select(.address == "${key}")
               return_path: true
         autoscaler:
@@ -19,7 +19,7 @@ compute_resource:
             - '(.configuration.root_module.resources[] | select(.expressions.target?.references[]? == "${this.address}") | .address)'
             reference:
               paths:
-                - select(.address == "${key}")
+                - cbf::all_select("address";  "${key}")
                 -  map(select(.address == "${key}"))
                 - .prior_state.values.root_module.resources[] | select(.address == "${key}")
               return_path: true
@@ -35,12 +35,23 @@ compute_resource:
           reference:
             json_file: gcp_machines_types
             property: "vcpus"
+        - paths: "${template_config}.values.machine_type"
+          regex:
+            pattern: ".*custom-([0-9]+)-.*"
+            group: 1
+            value_type: integer
       memory:
         - paths: "${template_config}.values.machine_type"
           unit: mb
           reference:
             json_file: gcp_machines_types
             property: "memoryMb"
+        - paths: "${template_config}.values.machine_type"
+          unit: mb
+          regex:
+            pattern: ".*custom-[0-9]+-([0-9]+).*"
+            group: 1
+            value_type: integer
       zone:
         - paths: ".values.zone"
       region:

--- a/internal/plan/mappings/gcp/general.yaml
+++ b/internal/plan/mappings/gcp/general.yaml
@@ -10,3 +10,4 @@ general:
     ignored_resources:
       - ".*_template"
       - "google_compute_autoscaler"
+      - "google_container_node_pool"

--- a/internal/plan/mappings/gcp/gke.yaml
+++ b/internal/plan/mappings/gcp/gke.yaml
@@ -1,0 +1,154 @@
+compute_resource:
+  google_container_cluster:
+    paths:
+      - cbf::all_select("type";  "google_container_cluster")
+    type: resource
+    variables:
+      properties:
+        node_pool:
+          - paths:
+              - '.configuration.root_module.resources[] | select(any(.expressions.cluster.references[]?; . == "${this.address}")) | .address'
+            reference:
+              paths:
+                - cbf::all_select("address";  "${key}") | .values
+                - .prior_state.values.root_module.resources[] | select(.address == "${key}") | .values
+              return_path: true
+          - default: '.values.node_pool[0]'
+        nb_zones :
+          - paths: 
+            - ".values.node_locations | length"
+            - "${node_pool}.node_locations | length"
+    properties:
+      name:
+        - paths: ".name"
+      address:
+        - paths: ".address"
+      type:
+        - paths: ".type"
+      vCPUs:
+        - paths: 
+          - ".values.node_config[].machine_type"
+          - "${node_pool}.node_config[].machine_type"
+          reference:
+            json_file: gcp_machines_types
+            property: "vcpus"
+        - paths: 
+          - ".values.node_config[].machine_type"
+          - "${node_pool}.node_config[].machine_type"
+          regex:
+            pattern: ".*custom-([0-9]+)-.*"
+            group: 1
+            value_type: integer
+        - paths: 
+          - ".values.cluster_autoscaling[0] | select(.enabled != false) | .resource_limits[] | select(.resource_type == \"cpu\" and .maximum != null) | ((.minimum // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.maximum - (.minimum // 1))))"
+          - ".values.cluster_autoscaling[0] | select(.enabled == false) | .resource_limits[] | select(.resource_type == \"cpu\") | (.minimum // 1)"
+          validator : "if . == null then error(\"The number of vCPUs of nodes must set. Does it have a minimum and a maxium value? \") else . end"
+      memory:
+        - paths: 
+          - ".values.node_config[].machine_type"
+          - "${node_pool}.node_config[].machine_type"
+          unit: mb
+          reference:
+            json_file: gcp_machines_types
+            property: "memoryMb"
+        - paths: 
+          - ".values.node_config[].machine_type"
+          - "${node_pool}.node_config[].machine_type"
+          unit: mb
+          regex:
+            pattern: ".*custom-[0-9]+-([0-9]+).*"
+            group: 1
+            value_type: integer
+        - paths: 
+          - ".values.cluster_autoscaling[0] | select(.enabled != false) | .resource_limits[] | select(.resource_type == \"memory\" and .maximum != null) | ((.minimum // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.maximum - (.minimum // 1))))"
+          - ".values.cluster_autoscaling[0] | select(.enabled == false) | .resource_limits[] | select(.resource_type == \"memory\") | (.minimum // 1)"
+          validator : "if . == null then error(\"The memory size of nodes must be set. Does it have a minimum and a maxium value? \") else . end"
+          unit: gb
+      zone:
+        - paths: 
+          - ".values.node_locations"
+          - "${node_pool}.node_locations"
+      region:
+        - paths: 
+          - ".values.location"
+          - ".values.node_locations[0]"
+          - "${node_pool}.location"
+          - "${node_pool}.node_locations[0]"
+          regex:
+            pattern: "^([^-]+-[^-]+)(-.*)?$"
+            group: 1
+      count:
+        - paths: 
+          - "${node_pool}.autoscaling[0] | select(.total_max_node_count != null) |(.total_min_node_count // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.total_max_node_count - (.total_min_node_count // 1)))"
+          - "(if ${nb_zones} == 0 then 1 else ${nb_zones} end) * (${node_pool}.autoscaling[0] | select(.max_node_count != null) | (.min_node_count // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.max_node_count - (.min_node_count // 1))))"
+          - "(( (${node_pool}.node_locations ) // .values.node_locations // [\"dummy_region\"]) | length) * (${node_pool}.autoscaling[0] | select(.max_node_count != null) | (.min_node_count // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.max_node_count - (.min_node_count // 1))))"
+          - "${node_pool}.node_count"
+          - ".values.initial_node_count"
+      guest_accelerator:
+        - type: list
+          item:
+            - paths: 
+              - ".values.node_config[]?.guest_accelerator"
+              - "${node_pool}.node_config[].guest_accelerator"
+              properties:
+                count:
+                  - paths: ".count"
+                    type: integer
+                type:
+                  - paths: ".type"
+                    type: string
+            - paths: ".values.cluster_autoscaling[0] | select(.enabled != false) | .resource_limits[] | select(.resource_type != \"memory\" and .resource_type != \"cpu\")"
+              properties:
+                count:
+                  - paths: "(.minimum // 1) + (${config.provider.gcp.avg_autoscaler_size_percent} * (.maximum - (.minimum // 1)))"
+                    validator : "if . <= 0 then error(\"The number of GPU of nodes must be bigger than zero. Does it have a minimum and a maxium value? \") else . end"
+                    type: integer
+                type:
+                  - paths: ".resource_type"
+                    type: string
+      storage:
+        - type: list
+          item:
+            - paths: 
+              - .values.node_config[]
+              - ${node_pool}.node_config[]
+              - .values.cluster_autoscaling[0].auto_provisioning_defaults
+              properties:
+                size:
+                  - paths: 
+                    - ".disk_size_gb"
+                    - ".disk_size"
+                    unit: gb
+                  - default: 10
+                type:
+                  - paths: ".disk_type"
+                    default: pd-standard
+                    reference:
+                      general: disk_types
+            - paths: 
+              - .values.node_config[]
+              - ${node_pool}.node_config[]
+              properties:
+                size:
+                  - paths: "(.local_ssd_count? // 0 )* 375"
+                    unit: gb
+                type: 
+                  - default : ssd
+            - paths: 
+              - .values.node_config[].ephemeral_storage_local_ssd_config
+              - ${node_pool}.node_config[].ephemeral_storage_local_ssd_config
+              properties:
+                size:
+                  - paths: "(.local_ssd_count? // 0 )* 375"
+                    unit: gb
+                type: 
+                  - default : ssd
+            - paths: 
+              - .values.node_config[].local_nvme_ssd_block_config
+              - ${node_pool}.node_config[].local_nvme_ssd_block_config
+              properties:
+                size:
+                  - paths: "(.local_ssd_count? // 0 )* 375"
+                    unit: gb
+                type: 
+                  - default : ssd

--- a/internal/plan/mappings/gcp/sql_database.yaml
+++ b/internal/plan/mappings/gcp/sql_database.yaml
@@ -1,6 +1,6 @@
 compute_resource:
   google_sql_database_instance:
-    paths: select(.type == "google_sql_database_instance")
+    paths: cbf::all_select("type";  "google_sql_database_instance")
     type: resource
     properties:
       name:

--- a/internal/plan/resolver.go
+++ b/internal/plan/resolver.go
@@ -121,3 +121,17 @@ func resolveRegex(value string, regex Regex) (string, error) {
 	return "", fmt.Errorf("No match found for regex %v in value %v", regex.Pattern, value)
 
 }
+
+func applyValidator(valueFound interface{}, propertyMapping *PropertyDefinition, context *tfContext) error {
+	if propertyMapping == nil || propertyMapping.Validator == nil {
+		return nil
+	}
+	validator := propertyMapping.Validator
+	err := resolveValidator(valueFound, validator, context)
+	return err
+}
+
+func resolveValidator(value interface{}, validator *string, context *tfContext) error {
+	_, err := getJSON(*validator, value)
+	return errors.Wrapf(err, "Cannot validate '%v' value of %v", value, context.ResourceAddress)
+}

--- a/internal/plan/test/resources_gcp_gke_test.go
+++ b/internal/plan/test/resources_gcp_gke_test.go
@@ -1,0 +1,165 @@
+package plan_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/carboniferio/carbonifer/internal/plan"
+	"github.com/carboniferio/carbonifer/internal/providers"
+	"github.com/carboniferio/carbonifer/internal/resources"
+	"github.com/carboniferio/carbonifer/internal/terraform"
+	"github.com/carboniferio/carbonifer/internal/testutils"
+	"github.com/shopspring/decimal"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetResource_GCP_GKE(t *testing.T) {
+	testutils.SkipWithCreds(t)
+
+	// reset
+	terraform.ResetTerraformExec()
+
+	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", "")
+
+	wd := path.Join(testutils.RootDir, "test/terraform/gcp_gke")
+	viper.Set("workdir", wd)
+
+	wantResources := map[string]resources.Resource{
+		"google_container_cluster.my_cluster": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        5,
+				Address:      "google_container_cluster.my_cluster",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(2725),
+			},
+		},
+		"google_container_cluster.my_cluster_no_pool": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster_no_pool",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        4,
+				Address:      "google_container_cluster.my_cluster_no_pool",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(950),
+			},
+		},
+		"google_container_cluster.auto_provisioned": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "auto_provisioned",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        1,
+				Address:      "google_container_cluster.auto_provisioned",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(5),
+				MemoryMb:          int32(10240),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(300),
+				GpuTypes:          []string{"nvidia-tesla-k80", "nvidia-tesla-k80", "nvidia-tesla-k80"},
+			},
+		},
+		"google_container_cluster.my_cluster_sub_pool": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster_sub_pool",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        1,
+				Address:      "google_container_cluster.my_cluster_sub_pool",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(950),
+			},
+		},
+		"google_container_cluster.my_cluster_autoscaled": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster_autoscaled",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        36,
+				Address:      "google_container_cluster.my_cluster_autoscaled",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(150),
+			},
+		},
+		"google_container_cluster.my_cluster_autoscaled_monozone": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster_autoscaled_monozone",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        12,
+				Address:      "google_container_cluster.my_cluster_autoscaled_monozone",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(150),
+			},
+		},
+		"google_container_cluster.my_cluster_autoscaled_total": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Name:         "my_cluster_autoscaled_total",
+				ResourceType: "google_container_cluster",
+				Provider:     providers.GCP,
+				Region:       "europe-west9",
+				Count:        70,
+				Address:      "google_container_cluster.my_cluster_autoscaled_total",
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:             int32(2),
+				MemoryMb:          int32(7680),
+				ReplicationFactor: 1,
+				HddStorage:        decimal.Zero,
+				SsdStorage:        decimal.NewFromInt(150),
+			},
+		},
+	}
+	tfPlan, err := terraform.TerraformPlan()
+	assert.NoError(t, err)
+	gotResources, err := plan.GetResources(tfPlan)
+	assert.NoError(t, err)
+	for _, got := range gotResources {
+		if got.GetIdentification().ResourceType == "google_container_node_pool" {
+			// This should not exists, it should be ignored
+			assert.Fail(t, "google_container_node_pool should be ignored")
+		} else if got.GetIdentification().ResourceType == "google_container_cluster" {
+			assert.Equal(t, wantResources[got.GetAddress()], got)
+		} else {
+			// Anything else should be unsupported
+			assert.IsType(t, resources.UnsupportedResource{}, got)
+		}
+	}
+}

--- a/internal/plan/test/resources_gcp_test.go
+++ b/internal/plan/test/resources_gcp_test.go
@@ -1,7 +1,6 @@
 package plan_test
 
 import (
-	"log"
 	"path"
 	"testing"
 
@@ -272,7 +271,6 @@ func TestGetResources_DiskImage(t *testing.T) {
 		assert.Equal(t, len(wantResources), len(resourceList))
 		for i, resource := range resourceList {
 			wantResource := wantResources[i]
-			log.Println(resource.(resources.ComputeResource).Specs.HddStorage)
 			assert.EqualValues(t, wantResource, resource)
 		}
 	}

--- a/internal/utils/jsonQuery.go
+++ b/internal/utils/jsonQuery.go
@@ -1,18 +1,45 @@
 package utils
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
 	"github.com/itchyny/gojq"
 )
 
+type moduleLoader struct{}
+
+func (*moduleLoader) LoadModule(name string) (*gojq.Query, error) {
+	switch name {
+	case "carbonifer":
+		return gojq.Parse(`
+			module { name: "carbonifer" };
+
+			def all_select(a; b):
+				.planned_values | .. | objects | select(has("resources")) | .resources[] | select(.[a] == b);
+		`)
+	}
+	return nil, fmt.Errorf("module not found: %q", name)
+}
+
 // GetJSON returns the result of a jq query on a json object
 func GetJSON(query string, json interface{}) ([]interface{}, error) {
-	queryParsed, err := gojq.Parse(query)
+	queryImport := fmt.Sprintf(`import "carbonifer" as cbf; %s`, query)
+	queryParsed, err := gojq.Parse(queryImport)
+	if err != nil {
+		log.Fatal(err)
+		return nil, err
+	}
+
+	code, err := gojq.Compile(
+		queryParsed, *getGoJQWithModules(),
+	)
 	if err != nil {
 		return nil, err
 	}
-	iter := queryParsed.Run(json)
+
+	iter := code.Run(json)
 	results := []interface{}{}
 	for {
 		v, ok := iter.Next()
@@ -33,4 +60,14 @@ func GetJSON(query string, json interface{}) ([]interface{}, error) {
 	}
 
 	return results, nil
+}
+
+var goJqWithModules *gojq.CompilerOption
+
+func getGoJQWithModules() *gojq.CompilerOption {
+	if goJqWithModules == nil {
+		goJqWithModulesObj := gojq.WithModuleLoader(&moduleLoader{})
+		goJqWithModules = &goJqWithModulesObj
+	}
+	return goJqWithModules
 }

--- a/test/terraform/gcp_gke/autoprovisioned.tf
+++ b/test/terraform/gcp_gke/autoprovisioned.tf
@@ -1,0 +1,32 @@
+resource "google_container_cluster" "auto_provisioned" {
+  name = "${var.project_id}-gke"
+  project = var.project_id
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  location = var.region
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+
+  cluster_autoscaling {
+    resource_limits {
+      resource_type = "cpu"
+      minimum = 1
+      maximum = 10
+    }
+    resource_limits {
+      resource_type = "memory"
+      minimum = 4
+      maximum = 16
+    }
+    resource_limits {
+      resource_type = "nvidia-tesla-k80"
+      minimum = 2
+      maximum = 4
+    }
+    auto_provisioning_defaults {
+      disk_size = 300
+      disk_type = "pd-ssd"
+    }
+  }
+}

--- a/test/terraform/gcp_gke/autoscaling.tf
+++ b/test/terraform/gcp_gke/autoscaling.tf
@@ -1,0 +1,109 @@
+resource "google_container_cluster" "my_cluster_autoscaled" {
+  name = "${var.project_id}-gke"
+  project = var.project_id
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  node_locations = [ "${var.region}-a", "${var.region}-b", "${var.region}-c" ]
+
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}
+
+resource "google_container_node_pool" "gke_nodes_autoscaled" {
+  name       = google_container_cluster.my_cluster_autoscaled.name
+  cluster    = google_container_cluster.my_cluster_autoscaled.id
+
+  autoscaling {
+    min_node_count = 4
+    max_node_count = 20
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    preemptible  = true
+    machine_type = "n1-standard-2"
+    disk_size_gb = 150
+    disk_type = "pd-ssd"
+  }
+}
+
+resource "google_container_cluster" "my_cluster_autoscaled_monozone" {
+  name = "${var.project_id}-gke"
+  project = var.project_id
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  location = var.region
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}
+
+resource "google_container_node_pool" "gke_nodes_autoscaled_monozone" {
+  name       = google_container_cluster.my_cluster_autoscaled_monozone.name
+  cluster    = google_container_cluster.my_cluster_autoscaled_monozone.id
+
+  autoscaling {
+    min_node_count = 4
+    max_node_count = 20
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    preemptible  = true
+    machine_type = "n1-standard-2"
+    disk_size_gb = 150
+    disk_type = "pd-ssd"
+  }
+}
+
+resource "google_container_cluster" "my_cluster_autoscaled_total" {
+  name = "${var.project_id}-gke"
+  project = var.project_id
+  remove_default_node_pool = true
+  initial_node_count       = 5
+  node_locations = [ "${var.region}-a", "${var.region}-b", "${var.region}-c" ]
+
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}
+
+resource "google_container_node_pool" "gke_nodes_autoscaled_total" {
+  name       = google_container_cluster.my_cluster_autoscaled_total.name
+  cluster    = google_container_cluster.my_cluster_autoscaled_total.id
+
+  autoscaling {
+    total_min_node_count = 40
+    total_max_node_count = 100
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    preemptible  = true
+    machine_type = "n1-standard-2"
+    disk_size_gb = 150
+    disk_type = "pd-ssd"
+  }
+}

--- a/test/terraform/gcp_gke/main.tf
+++ b/test/terraform/gcp_gke/main.tf
@@ -1,0 +1,67 @@
+resource "google_container_cluster" "my_cluster" {
+  name = "${var.project_id}-gke"
+  project = var.project_id
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}
+
+resource "google_container_node_pool" "gke_nodes" {
+  name       = google_container_cluster.my_cluster.name
+  cluster    = google_container_cluster.my_cluster.id
+  node_count = var.num_nodes
+  node_locations = [ "${var.region}-a", "${var.region}-b", "${var.region}-c" ]
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    preemptible  = true
+    machine_type = "n1-standard-2"
+    disk_size_gb = 100
+    disk_type = "pd-ssd"
+    ephemeral_storage_local_ssd_config {
+      local_ssd_count = 4
+    }
+    local_nvme_ssd_block_config {
+      local_ssd_count = 2
+    }
+    local_ssd_count = 1
+  }
+}
+
+
+resource "google_container_cluster" "my_cluster_no_pool" {
+  name = "${var.project_id}-gke-2"
+  project = var.project_id
+  node_locations = [ "${var.region}-a", "${var.region}-b", "${var.region}-c" ]
+  remove_default_node_pool = true
+  initial_node_count       = 4
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    preemptible  = true
+    machine_type = "n1-standard-2"
+    disk_size_gb = 200
+    disk_type = "pd-ssd"
+    ephemeral_storage_local_ssd_config {
+      local_ssd_count = 2
+    }
+  }
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}

--- a/test/terraform/gcp_gke/network.tf
+++ b/test/terraform/gcp_gke/network.tf
@@ -1,0 +1,5 @@
+module "network" {
+  source = "../gcp_global_module/network"
+  project_id = var.project_id
+  region = var.region
+}

--- a/test/terraform/gcp_gke/provider.tf
+++ b/test/terraform/gcp_gke/provider.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  region      = var.region
+}

--- a/test/terraform/gcp_gke/sub_node_pool.tf
+++ b/test/terraform/gcp_gke/sub_node_pool.tf
@@ -1,0 +1,31 @@
+
+resource "google_container_cluster" "my_cluster_sub_pool" {
+  name = "${var.project_id}-gke-2"
+  project = var.project_id
+  node_locations = [ "${var.region}-a", "${var.region}-b", "${var.region}-c" ]
+
+  node_pool {
+    name = "my-sub-pool"
+    initial_node_count = 4
+    node_config {
+      oauth_scopes = [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ]
+
+      labels = {
+        env = var.project_id
+      }
+
+      preemptible  = true
+      machine_type = "n1-standard-2"
+      disk_size_gb = 200
+      disk_type = "pd-ssd"
+      ephemeral_storage_local_ssd_config {
+        local_ssd_count = 2
+      }
+    }
+  }
+
+  network    = module.network.vpc_name
+  subnetwork = module.network.subnet_name
+}

--- a/test/terraform/gcp_gke/variables.tf
+++ b/test/terraform/gcp_gke/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  default = "europe-west9"
+}
+
+variable "project_id" {
+  default = "cbf-terraform"
+}
+
+variable "num_nodes" {
+  default = 5
+}

--- a/test/terraform/gcp_global_module/network/main.tf
+++ b/test/terraform/gcp_global_module/network/main.tf
@@ -1,0 +1,14 @@
+resource "google_compute_network" "vpc_network" {
+  name                    = "cbf-network"
+  auto_create_subnetworks = false
+  mtu                     = 1460
+  project                 = var.project_id
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "cbf-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = var.region
+  network       = google_compute_network.vpc_network.id
+  project       = var.project_id
+}

--- a/test/terraform/gcp_global_module/network/output.tf
+++ b/test/terraform/gcp_global_module/network/output.tf
@@ -1,0 +1,8 @@
+output "subnet_name" {
+  value = google_compute_subnetwork.default.name
+}
+
+output "vpc_name" {
+  value = google_compute_network.vpc_network.name
+}
+

--- a/test/terraform/gcp_global_module/network/variables.tf
+++ b/test/terraform/gcp_global_module/network/variables.tf
@@ -1,0 +1,2 @@
+variable "project_id" {}
+variable "region" {}


### PR DESCRIPTION
This adds support for Google Kubernetes Engine:

- `google_container_cluster` with default pool
  - fixed size
  - [nested cluster autoscaling](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_cluster_autoscaling)
- `google_container_cluster` with pool defined in `google_container_node_pool`
  - fixed size
  - [autoscaling](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#nested_autoscaling)

As similar as `google_compute_autoscaler` autoscaling takes the average using a factor declared in [config file ](https://github.com/carboniferio/carbonifer/blob/main/README.md#configuration)

This example is what is used by default. But feel free to adjust if necessary
```
provider:
  gcp:
    avg_autoscaler_size_percent: 0.5
```

So it mean if you have a min of 4 instances and a max of 10 instances, it will be `min + 0.5 * ( max - min)` which is `5 + 0.5 * (10-4) = 8`