### PR TITLE
[AWS] Fix: override disk when mounted on same device name

### DIFF
--- a/internal/plan/mappings/aws/ec2_asg.yaml
+++ b/internal/plan/mappings/aws/ec2_asg.yaml
@@ -62,35 +62,69 @@ compute_resource:
       storage:
         - type: list
           item:
-            - paths: '${ami}.values.block_device_mappings[].ebs | select(length > 0)'
+            - paths: '${ami}.values.block_device_mappings[] | select(length > 0)'
               properties:
                 size:
-                  - paths: ".volume_size"
+                  - paths: ".ebs.volume_size"
                     default: 8
                     unit: gb
                 type:
-                  - paths: ".volume_type"
+                  - paths: ".ebs.volume_type"
                     default: standard
                     reference:
                       general: disk_types 
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default: 2
             - paths: 
               - '${launch_configuration}.values.ebs_block_device[] | select(length > 0)'
-              - '${launch_configuration}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name == null or (.virtual_name | startswith("ephemeral") | not)) | .ebs'
               properties:
                 size:
-                  - paths: ".volume_size"
+                  - paths: 
+                    - ".volume_size"
                     unit: gb
-                  - paths: ".snapshot_id"
+                  - paths: 
+                     - ".snapshot_id"
                     reference:
                       paths: .prior_state.values.root_module.resources[] | select(.values.id == "${key}") | .values
                       property: ".volume_size"
                   - default: 8
                     unit: gb
                 type:
-                  - paths: ".volume_type"
+                  - paths: 
+                    - ".volume_type"
                     default: standard
                     reference:
                       general: disk_types
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default: 0
+            - paths:
+              - '${launch_configuration}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name == null or (.virtual_name | startswith("ephemeral") | not)) | select(.ebs != null)'
+              properties:
+                size:
+                  - paths: 
+                    - ".ebs[0].volume_size"
+                    unit: gb
+                  - paths: 
+                     - ".ebs[0].snapshot_id"
+                    reference:
+                      paths: .prior_state.values.root_module.resources[] | select(.values.id == "${key}") | .values
+                      property: ".volume_size"
+                  - default: 8
+                    unit: gb
+                type:
+                  - paths: 
+                    - ".ebs[0].volume_type"
+                    default: standard
+                    reference:
+                      general: disk_types
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default: 1
             - paths: 
               - '${launch_configuration}.values.ephemeral_block_device[] | select(length > 0)'
               - '${launch_configuration}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name != null and (.virtual_name | startswith("ephemeral")))'

--- a/internal/plan/mappings/aws/ec2_instance.yaml
+++ b/internal/plan/mappings/aws/ec2_instance.yaml
@@ -65,35 +65,69 @@ compute_resource:
         - type: list
           item:
             - paths: 
-              - '${ami}.values.block_device_mappings[] | select(length > 0) | .ebs'
+              - '${ami}.values.block_device_mappings[] | select(length > 0)'
               properties:
                 size:
-                  - paths: ".volume_size"
+                  - paths: ".ebs.volume_size"
                     default: 8
                     unit: gb
                 type:
-                  - paths: ".volume_type"
+                  - paths: ".ebs.volume_type"
                     default: standard
                     reference:
-                      general: disk_types 
+                      general: disk_types
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default: 2
             - paths: 
               - '.values.ebs_block_device[] | select(length > 0)'
-              - '${launch_template}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name == null or .virtual_name == "" or (.virtual_name | startswith("ephemeral") | not)) | .ebs'
               properties:
                 size:
-                  - paths: ".volume_size"
+                  - paths: 
+                    - ".volume_size"
                     unit: gb
-                  - paths: ".snapshot_id"
+                  - paths: 
+                    - ".snapshot_id"
                     reference:
                       paths: .prior_state.values.root_module.resources[] | select(.values.id == "${key}") | .values
                       property: ".volume_size"
                   - default: 8
                     unit: gb
                 type:
-                  - paths: ".volume_type"
+                  - paths: 
+                    - ".volume_type"
                     default: standard
                     reference:
                       general: disk_types
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default : 0
+            - paths:
+              - '${launch_template}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name == null or .virtual_name == "" or (.virtual_name | startswith("ephemeral") | not)) | select(.ebs != null)'
+              properties:
+                size:
+                  - paths: 
+                    - ".ebs[0].volume_size"
+                    unit: gb
+                  - paths: 
+                    - ".ebs[0].snapshot_id"
+                    reference:
+                      paths: .prior_state.values.root_module.resources[] | select(.values.id == "${key}") | .values
+                      property: ".volume_size"
+                  - default: 8
+                    unit: gb
+                type:
+                  - paths: 
+                    - ".ebs[0].volume_type"
+                    default: standard
+                    reference:
+                      general: disk_types
+                key:
+                  - paths: ".device_name | cbf::extract_disk_key"
+                override_priority: 
+                  - default : 1
             - paths: 
               - '.values.ephemeral_block_device[] | select(length > 0)'
               - '${launch_template}.values.block_device_mappings[] | select(length > 0) | select(.virtual_name != null and (.virtual_name | startswith("ephemeral")))'

--- a/internal/plan/resolver.go
+++ b/internal/plan/resolver.go
@@ -13,8 +13,10 @@ import (
 )
 
 type storage struct {
-	SizeGb decimal.Decimal
-	IsSSD  bool
+	SizeGb           decimal.Decimal
+	IsSSD            bool
+	OverridePriority int
+	Key              *string
 }
 
 func applyReference(valueFound string, propertyMapping *PropertyDefinition, context *tfContext) (interface{}, error) {

--- a/internal/plan/resolver.go
+++ b/internal/plan/resolver.go
@@ -16,7 +16,7 @@ type storage struct {
 	SizeGb           decimal.Decimal
 	IsSSD            bool
 	OverridePriority int
-	Key              *string
+	Key              string
 }
 
 func applyReference(valueFound string, propertyMapping *PropertyDefinition, context *tfContext) (interface{}, error) {

--- a/internal/plan/resources.go
+++ b/internal/plan/resources.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/carboniferio/carbonifer/internal/providers"
@@ -305,21 +306,7 @@ func GetComputeResource(resourceI interface{}, resourceMapping *ResourceMapping,
 		return nil, errors.Wrapf(err, "Cannot get storages for %v", resourceAddress)
 	}
 
-	for i, storageI := range storages {
-		if storageI == nil {
-			continue
-		}
-		storage, err := getStorage(storageI.(map[string]interface{}))
-		if err != nil {
-			return nil, errors.Wrapf(err, "Cannot get storage[%v] for %v", i, resourceAddress)
-		}
-		size := storage.SizeGb
-		if storage.IsSSD {
-			computeResource.Specs.SsdStorage = computeResource.Specs.SsdStorage.Add(size)
-		} else {
-			computeResource.Specs.HddStorage = computeResource.Specs.HddStorage.Add(size)
-		}
-	}
+	processStorages(storages, &computeResource, context)
 
 	resourcesResult = append(resourcesResult, computeResource)
 	log.Debugf("    Reading resource '%s'", computeResource.GetAddress())
@@ -344,6 +331,50 @@ func getGPU(gpu map[string]interface{}) ([]string, error) {
 		}
 	}
 	return gpuTypes, nil
+}
+
+func processStorages(storagesI []interface{}, computeResource *resources.ComputeResource, context *tfContext) error {
+	storagesByKey := map[string][]*storage{}
+	for i, storageI := range storagesI {
+		if storageI == nil {
+			continue
+		}
+		storageItem, err := getStorage(storageI.(map[string]interface{}))
+		if err != nil {
+			return errors.Wrapf(err, "Cannot get storage[%v] for %v", i, context.ResourceAddress)
+		}
+		if storagesByKey[*storageItem.Key] == nil {
+			storagesByKey[*storageItem.Key] = []*storage{storageItem}
+		} else {
+			storagesByKey[*storageItem.Key] = append(storagesByKey[*storageItem.Key], storageItem)
+		}
+	}
+
+	for _, storages := range storagesByKey {
+		// Take the storage with the lower priority in the list
+		storages = sortStorages(storages)
+		storageItem := storages[0]
+
+		size := storageItem.SizeGb
+		if storageItem.IsSSD {
+			computeResource.Specs.SsdStorage = computeResource.Specs.SsdStorage.Add(size)
+		} else {
+			computeResource.Specs.HddStorage = computeResource.Specs.HddStorage.Add(size)
+		}
+	}
+
+	return nil
+}
+
+func sortStorages(storages []*storage) []*storage {
+	if len(storages) == 0 {
+		return storages
+	}
+	// sort by override_priority, lowest priority first
+	sort.Slice(storages, func(i, j int) bool {
+		return storages[i].OverridePriority < storages[j].OverridePriority
+	})
+	return storages
 }
 
 func getStorage(storageMap map[string]interface{}) (*storage, error) {
@@ -400,9 +431,24 @@ func getStorage(storageMap map[string]interface{}) (*storage, error) {
 			isSSD = true
 		}
 	}
+	overridePriority := 0
+	overridePriorityI := storageMap["override_priority"]
+	if overridePriorityI != nil {
+		overridePriority = overridePriorityI.(*valueWithUnit).Value.(int)
+	}
+
+	var key *string
+	keyI := storageMap["key"]
+	if keyI != nil {
+		keyString := keyI.(*valueWithUnit).Value.(string)
+		key = &keyString
+	}
+
 	storage := storage{
-		SizeGb: storageSizeGb,
-		IsSSD:  isSSD,
+		SizeGb:           storageSizeGb,
+		IsSSD:            isSSD,
+		OverridePriority: overridePriority,
+		Key:              key,
 	}
 	return &storage, nil
 }

--- a/internal/plan/resources.go
+++ b/internal/plan/resources.go
@@ -306,7 +306,10 @@ func GetComputeResource(resourceI interface{}, resourceMapping *ResourceMapping,
 		return nil, errors.Wrapf(err, "Cannot get storages for %v", resourceAddress)
 	}
 
-	processStorages(storages, &computeResource, context)
+	err = processStorages(storages, &computeResource, context)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Cannot process storages for %v", resourceAddress)
+	}
 
 	resourcesResult = append(resourcesResult, computeResource)
 	log.Debugf("    Reading resource '%s'", computeResource.GetAddress())

--- a/internal/plan/test/resources_aws_asg_test.go
+++ b/internal/plan/test/resources_aws_asg_test.go
@@ -58,7 +58,7 @@ func TestGetResource_AWSASG(t *testing.T) {
 				MemoryMb: int32(16384),
 
 				HddStorage: decimal.NewFromInt(300),
-				SsdStorage: decimal.NewFromInt(30 + 150),
+				SsdStorage: decimal.NewFromInt(150),
 			},
 		},
 	}

--- a/internal/plan/test/resources_aws_test.go
+++ b/internal/plan/test/resources_aws_test.go
@@ -90,8 +90,26 @@ func TestGetResource_EC2(t *testing.T) {
 				VCPUs:    int32(4),
 				MemoryMb: int32(16384),
 
+				HddStorage: decimal.Zero,
+				SsdStorage: decimal.NewFromInt(180),
+			},
+		},
+		"aws_instance.ec2_with_lt_disk_override": resources.ComputeResource{
+			Identification: &resources.ResourceIdentification{
+				Address:           "aws_instance.ec2_with_lt_disk_override",
+				Name:              "ec2_with_lt_disk_override",
+				ResourceType:      "aws_instance",
+				Provider:          providers.AWS,
+				Region:            "eu-west-3",
+				Count:             1,
+				ReplicationFactor: 1,
+			},
+			Specs: &resources.ComputeResourceSpecs{
+				VCPUs:    int32(4),
+				MemoryMb: int32(16384),
+
 				HddStorage: decimal.NewFromInt(300),
-				SsdStorage: decimal.NewFromInt(30 + 150),
+				SsdStorage: decimal.NewFromInt(150),
 			},
 		},
 	}

--- a/internal/utils/jsonQuery.go
+++ b/internal/utils/jsonQuery.go
@@ -18,6 +18,15 @@ func (*moduleLoader) LoadModule(name string) (*gojq.Query, error) {
 
 			def all_select(a; b):
 				.planned_values | .. | objects | select(has("resources")) | .resources[] | select(.[a] == b);
+
+			def extract_disk_key:
+				if test("^/dev/sd[a-z]+") or test("^/dev/xvd[a-z]+") then
+				  capture("^/dev/(?:sd|xvd)(?<letter>[a-z]+)").letter
+				elif test("^/dev/nvme[0-2]?[0-9]n") then
+				  capture("^/dev/nvme(?<number>[0-2]?[0-9])n").number | tonumber | (96 + .) | [.] | implode
+				else
+				  "Unknown format"
+				end;
 		`)
 	}
 	return nil, fmt.Errorf("module not found: %q", name)

--- a/test/terraform/aws_ec2/ec2_launch_template.tf
+++ b/test/terraform/aws_ec2/ec2_launch_template.tf
@@ -4,6 +4,18 @@ resource "aws_launch_template" "my_launch_template" {
   instance_type = "m5d.xlarge"
 
   block_device_mappings {
+    device_name  = "/dev/sdb"
+    virtual_name = "ephemeral0"
+  }
+
+}
+
+resource "aws_launch_template" "my_launch_template_disk_override" {
+  name_prefix   = "my_launch_template"
+  image_id      = "${data.aws_ami.ubuntu.id}"
+  instance_type = "m5d.xlarge"
+
+  block_device_mappings {
     device_name = "/dev/sda1"
 
     ebs {
@@ -23,6 +35,13 @@ resource "aws_launch_template" "my_launch_template" {
 resource "aws_instance" "ec2_with_lt" {
     launch_template {
         id      = "${aws_launch_template.my_launch_template.id}"
+        version = "$$Latest"
+    }
+}
+
+resource "aws_instance" "ec2_with_lt_disk_override" {
+    launch_template {
+        id      = "${aws_launch_template.my_launch_template_disk_override.id}"
         version = "$$Latest"
     }
 }


### PR DESCRIPTION
## Problem
When two disks are mounted on the same device name, we need to use the value of the override. Typically this happens when a root disk size is set in the AMI and the EC2 instance sets a bigger size of this root disk. 

## New storage mapping extension 

So, in disk mapping we introduce two optional properties for storage items: `key` and `override_priority` :

```yaml
        size: <...>
        type: <...>
        key:
          - paths: ".device_name | cbf::extract_disk_key"
        override_priority: 
          - default : 0
```

If we have many disks set on the same device name, they will be ordered by `override_priority` and pick the lowest. Typically the disk set in the EC2 instance definition on `/dev/sda1` will override the disk set in the AMI on `/dev/sda1`

Those new properties are optional, if not see the `key` will be `""` (empty string) and no override mechanism will be applied to storage with no key set (case of GCP or ephemeral storage)

## Case AWS device naming 
On AWS, device name can be either in form of  or `/dev/nvme1n1`, and they are both the same (cf [aws doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html))!  In that case, an other custom jq method is introduced: 

```jq
  def extract_disk_key:
    if test("^/dev/sd[a-z]+") or test("^/dev/xvd[a-z]+") then
		    capture("^/dev/(?:sd|xvd)(?<letter>[a-z]+)").letter
    elif test("^/dev/nvme[0-2]?[0-9]n") then
		    capture("^/dev/nvme(?<number>[0-2]?[0-9])n").number | tonumber | (96 + .) | [.] | implode
    else
		    "Unknown format"
    end;
```

This function will pick the significative letter of the device name (example both `/dev/sda1` or `/dev/xvda` will be translated to `a` ) or the corresponding letter for nvme (example: `/dev/nvme3n1`, the significative number is 3 and the corresponding letter will be `c`)