### PR TITLE
Fix x86-64 installer file name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ elif [ "$OS" == "Linux" ]; then
 fi
 
 if [ "$ARCH" == "x86_64" ]; then
-  ARCH="amd64"
+  ARCH="x86_64"
 elif [ "$ARCH" == "arm64" ]; then
   ARCH="arm64"
 elif [ "$ARCH" == "aarch64" ]; then


### PR DESCRIPTION
The Linux x86-64 installer is called `carbonifer_Linux_x86_64.tar.gz` in the [latest release](https://github.com/carboniferio/carbonifer/releases/tag/v0.4.0). Fix the corresponding reference